### PR TITLE
Extending filewatching option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,17 @@ The plugin comes with the following defaults:
   -- args can be used to pass additional flags to the language server
     ]]
 
-    -- NOTE: Set `filewatching` to false if you experience performance problems.
-    -- Defaults to true, since turning it off is a hack.
+    -- NOTE: Set `filewatching` to 'force-nvim' if you experience performance problems.
+    -- Defaults to 'auto', since changing it is a hack.
     -- If you notice that the server is _super_ slow, it is probably because of file watching
     -- Neovim becomes super unresponsive on some large codebases, because it schedules the file watching on the event loop.
     -- This issue goes away by disabling this capability, but roslyn will fallback to its own file watching,
     -- which can make the server super slow to initialize.
-    -- Setting this option to false will indicate to the server that neovim will do the file watching.
+    -- Setting this option to 'force-nvim' will indicate to the server that neovim will do the file watching.
     -- However, in `hacks.lua` I will also just don't start off any watchers, which seems to make the server
     -- a lot faster to initialize.
-    filewatching = true,
+    -- You can also try 'force-ls'. This will disable neovim file watching capability and delegate it to the server.
+    filewatching = "auto",
 
     -- Optional function that takes an array of targets as the only argument. Return the target you
     -- want to use. If it returns `nil`, then it falls back to guessing the target like normal

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ The plugin comes with the following defaults:
   -- args can be used to pass additional flags to the language server
     ]]
 
-    -- NOTE: Set `filewatching` to 'force-nvim' if you experience performance problems.
+    -- NOTE: Set `filewatching` to 'off' if you experience performance problems.
     -- Defaults to 'auto', since changing it is a hack.
     -- If you notice that the server is _super_ slow, it is probably because of file watching
     -- Neovim becomes super unresponsive on some large codebases, because it schedules the file watching on the event loop.
     -- This issue goes away by disabling this capability, but roslyn will fallback to its own file watching,
     -- which can make the server super slow to initialize.
-    -- Setting this option to 'force-nvim' will indicate to the server that neovim will do the file watching.
+    -- Setting this option to 'off' will indicate to the server that neovim will do the file watching.
     -- However, in `hacks.lua` I will also just don't start off any watchers, which seems to make the server
     -- a lot faster to initialize.
-    -- You can also try 'force-ls'. This will disable neovim file watching capability and delegate it to the server.
+    -- You can also try 'roslyn'. This will disable neovim file watching capability and delegate it to the server.
     filewatching = "auto",
 
     -- Optional function that takes an array of targets as the only argument. Return the target you

--- a/README.md
+++ b/README.md
@@ -102,16 +102,11 @@ The plugin comes with the following defaults:
   -- args can be used to pass additional flags to the language server
     ]]
 
-    -- NOTE: Set `filewatching` to 'off' if you experience performance problems.
-    -- Defaults to 'auto', since changing it is a hack.
-    -- If you notice that the server is _super_ slow, it is probably because of file watching
-    -- Neovim becomes super unresponsive on some large codebases, because it schedules the file watching on the event loop.
-    -- This issue goes away by disabling this capability, but roslyn will fallback to its own file watching,
-    -- which can make the server super slow to initialize.
-    -- Setting this option to 'off' will indicate to the server that neovim will do the file watching.
-    -- However, in `hacks.lua` I will also just don't start off any watchers, which seems to make the server
-    -- a lot faster to initialize.
-    -- You can also try 'roslyn'. This will disable neovim file watching capability and delegate it to the server.
+    -- "auto" | "roslyn" | "off"
+    --
+    -- - "auto": Does nothing for filewatching, leaving everything as default
+    -- - "roslyn": Turns off neovim filewatching which will make roslyn do the filewatching
+    -- - "off": Hack to turn off all filewatching. (Can be used if you notice performance issues)
     filewatching = "auto",
 
     -- Optional function that takes an array of targets as the only argument. Return the target you

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 ---@class InternalRoslynNvimConfig
----@field filewatching string "auto" | "off" | "roslyn"
+---@field filewatching "auto" | "off" | "roslyn"
 ---@field exe string[]
 ---@field args string[]
 ---@field config vim.lsp.ClientConfig

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -12,7 +12,7 @@ function M.start(bufnr, root_dir, on_init)
     config.root_dir = root_dir
     config.handlers = vim.tbl_deep_extend("force", {
         ["client/registerCapability"] = function(err, res, ctx)
-            if not roslyn_config.filewatching then
+            if roslyn_config.filewatching == "force-nvim" then
                 for _, reg in ipairs(res.registrations) do
                     if reg.method == "workspace/didChangeWatchedFiles" then
                         reg.registerOptions.watchers = {}

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -12,7 +12,7 @@ function M.start(bufnr, root_dir, on_init)
     config.root_dir = root_dir
     config.handlers = vim.tbl_deep_extend("force", {
         ["client/registerCapability"] = function(err, res, ctx)
-            if roslyn_config.filewatching == "force-nvim" then
+            if roslyn_config.filewatching == "off" then
                 for _, reg in ipairs(res.registrations) do
                     if reg.method == "workspace/didChangeWatchedFiles" then
                         reg.registerOptions.watchers = {}


### PR DESCRIPTION
In some cases, language server does not see new .cs files. This breaks autocomplete, diagnostics and navigation. Restarting the server helps to solve the problem, but it's inconvenient to do it every time.

As discussed here https://github.com/seblyng/roslyn.nvim/issues/15 there is no good solution to fix the issue. There are only various hacks that can make life easier. So, I suggest changing `filewatching` option and adding another hack that disables `workspace.didChangeWatchedFiles.dynamicRegistration` in client capabilities.

Before
```lua
---@field filewatching boolean
```

After
```lua
---@field filewatching string auto | force-nvim | force-ls
```

Where:
* `auto` - do nothing and keep everything as is (default value) [same as old filewatching = true];
* `force-nvim` - indicates to the server that neovim will do the file watching + don't start any watchers (ls fast initialization) [same as old filewatching = false];
* `force-ls` - disables `workspace.didChangeWatchedFiles.dynamicRegistration` client capability and delegates filewatching to the server.