### PR TITLE
docs: Add type annotations to the plugin installation snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ There's currently an open [pull request](https://github.com/mason-org/mason-regi
 {
     "seblyng/roslyn.nvim",
     ft = "cs",
+    ---@module 'roslyn.config'
+    ---@type RoslynNvimConfig
     opts = {
         -- your configuration comes here; leave empty for default settings
     }


### PR DESCRIPTION
Hi!
What do you think about adding type annotations for the config in the readme? This would make it easier to configure the plugin with just lsp, without going to the browser.

With type annotations:

![image](https://github.com/user-attachments/assets/76b4a729-3e0b-40ac-bc94-22e53653f69d)

And without:

![image](https://github.com/user-attachments/assets/d170c94a-ac64-47b4-96a7-3f505a51b268)

There is one problem: when describing `vim.lsp.ClientConfig` (config node), we will get missing-fields diagnostics if cmd is not defined. I solved this by ignoring this diagnostic `---@diagnostic disable-next-line: missing-fields`, because the plugin starts the server correctly without cmd definition.

```lua
---@module 'roslyn.config'
---@type RoslynNvimConfig
opts = {
  filewatching = 'roslyn',
  ---@diagnostic disable-next-line: missing-fields
  config = {
    settings = {
      <my settings>
    },
  },
}
```
