### PR TITLE
Improve the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,16 @@ This setting controls how the language server should search for symbols.
   Search symbols in reference assemblies.  
   Expected values: `true`, `false`
 
+### Formatting
+
+`csharp|formatting`
+
+This setting controls how the language server should format code.
+
+- `dotnet_organize_imports_on_format`  
+  Sort using directives on format alphabetically.  
+  Expected values: `true`, `false`
+
 Example:
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ The plugin comes with the following defaults:
 
 To configure language server specific settings sent to the server, you can modify the `config.settings` map.
 
+Some tips and tricks that may be useful, but not in the scope of this plugin,
+are documented in the [wiki](https://github.com/seblyng/roslyn.nvim/wiki).
+
 > [!NOTE]  
 > These settings are not guaranteed to be up-to-date and new ones can appear in the future. Aditionally, not not all settings are shown here, but only the most relevant ones for Neovim. For a full list, visit [this](https://github.com/dotnet/vscode-csharp/blob/main/test/lsptoolshost/unitTests/configurationMiddleware.test.ts) unit test from the vscode extension and look especially for the ones which **don't** have `vsCodeConfiguration: null`.
 


### PR DESCRIPTION
It seems useful to add a description of the [`csharp|formatting.dotnet_organize_imports_on_format`](https://github.com/dotnet/vscode-csharp/blob/ce7942c32b237210d09f28b7f286e2ac2d0f98b3/test/lsptoolshost/unitTests/configurationMiddleware.test.ts#L271) option to the readme. The result of setting this option to true is shown below:

![03-24-2025-20-56-49](https://github.com/user-attachments/assets/a192fd13-932c-403e-a6bd-41636a6fd186)

Also, I didn't immediately notice that the plugin has a wiki (seems to be pretty rare for a plugin). What are your thoughts on adding a link to it?