### PR TITLE
fix!: remove some code that has been deprecated for a while

### DIFF
--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -109,49 +109,6 @@ function M.setup(user_config)
     roslyn_config = vim.tbl_deep_extend("force", roslyn_config, user_config or {})
     roslyn_config.exe = type(roslyn_config.exe) == "string" and { roslyn_config.exe } or roslyn_config.exe
 
-    if roslyn_config.ignore_sln then
-        vim.notify(
-            "The `ignore_sln` option is deprecated. Please use `ignore_target` instead, which also receives solution filter files if present",
-            vim.log.levels.WARN,
-            { title = "roslyn.nvim" }
-        )
-
-        if not roslyn_config.ignore_target then
-            roslyn_config.ignore_target = roslyn_config.ignore_sln
-        end
-    end
-
-    if roslyn_config.choose_sln then
-        vim.notify(
-            "The `choose_sln` option is deprecated. Please use `choose_target` instead, which also receives solution filter files if present",
-            vim.log.levels.WARN,
-            { title = "roslyn.nvim" }
-        )
-
-        if not roslyn_config.choose_target then
-            roslyn_config.choose_target = roslyn_config.choose_sln
-        end
-    end
-
-    if not vim.tbl_contains(roslyn_config.args, "--stdio") then
-        vim.notify(
-            "roslyn.nvim requires the `--stdio` argument to be present. Please add it to your configuration",
-            vim.log.levels.WARN,
-            { title = "roslyn.nvim" }
-        )
-        table.insert(roslyn_config.args, "--stdio")
-    end
-
-    -- filewatching: replace legacy boolean value (true -> auto; false -> off)
-    if type(roslyn_config.filewatching) == "boolean" then
-        roslyn_config.filewatching = roslyn_config.filewatching and "auto" or "off"
-        vim.notify(
-            "Value of the `filewatching` option should be 'auto' (default), 'off' or 'roslyn'.",
-            vim.log.levels.WARN,
-            { title = "roslyn.nvim" }
-        )
-    end
-
     -- HACK: Enable filewatching to later just not watch any files
     -- This is to not make the server watch files and make everything super slow in certain situations
     if roslyn_config.filewatching == "off" or roslyn_config.filewatching == "roslyn" then

--- a/lua/roslyn/init.lua
+++ b/lua/roslyn/init.lua
@@ -16,9 +16,6 @@ end
 
 local M = {}
 
----@type boolean
-local roslyn_version_verified = false
-
 ---@param config? RoslynNvimConfig
 function M.setup(config)
     local roslyn_config = require("roslyn.config").setup(config)
@@ -36,22 +33,6 @@ function M.setup(config)
                 return
             end
 
-            if not roslyn_version_verified then
-                -- TODO: Remove this in a few months or so
-                -- vim.system will fail with required args not provided if `--stdio` exists as an argument
-                -- to the version installed, so this should be safe
-                local cmd = vim.list_extend(vim.deepcopy(roslyn_config.exe), { "--stdio" })
-                local stderr = vim.system(cmd):wait().stderr
-                if stderr and string.find(stderr, "'--stdio'", 0, true) then
-                    return vim.notify(
-                        "The roslyn language server needs to be updated. Refer to the README for installation steps",
-                        vim.log.levels.INFO,
-                        { title = "roslyn.nvim" }
-                    )
-                end
-                roslyn_version_verified = true
-            end
-
             -- Lock the target and always start with the currently selected solution
             if roslyn_config.lock_target and vim.g.roslyn_nvim_selected_solution then
                 local sln_dir = vim.fs.dirname(vim.g.roslyn_nvim_selected_solution)
@@ -65,26 +46,17 @@ function M.setup(config)
                 local multiple, solution = utils.predict_target(root)
 
                 if multiple then
-                    -- If the user has `lock_target = true` then wait for them
-                    -- to choose a target explicitly before starting the LSP.
-                    --
-                    -- For `lock_target = false`, being asked to choose a target
-                    -- on every opened file would be annoying, so fall back to
-                    -- default handling.
-                    if roslyn_config.lock_target then
-                        vim.notify(
-                            "Multiple potential target files found. Use `:Roslyn target` to select a target.",
-                            vim.log.levels.INFO,
-                            { title = "roslyn.nvim" }
-                        )
-                        return
-                    end
-
                     vim.notify(
-                        "Multiple potential target files found. Use `:Roslyn target` to change the target for the current buffer.",
+                        "Multiple potential target files found. Use `:Roslyn target` to select a target.",
                         vim.log.levels.INFO,
                         { title = "roslyn.nvim" }
                     )
+
+                    -- If the user has `lock_target = true` then wait for them
+                    -- to choose a target explicitly before starting the LSP.
+                    if roslyn_config.lock_target then
+                        return
+                    end
                 end
 
                 if solution then

--- a/lua/roslyn/sln/api.lua
+++ b/lua/roslyn/sln/api.lua
@@ -67,25 +67,6 @@ function M.projects(target)
     return paths
 end
 
----Checks if a project is part of a solution or not
----@deprecated Renamed to `exists_in_target`.
----@param solution string
----@param project string Full path to the csproj file
----@return boolean
-function M.exists_in_solution(solution, project)
-    vim.notify(
-        "`exists_in_solution` has been renamed `exists_in_target` and may be removed in a future release",
-        vim.log.levels.WARN,
-        { title = "roslyn.nvim" }
-    )
-
-    local projects = M.projects(solution)
-
-    return vim.iter(projects):find(function(it)
-        return it == project
-    end) ~= nil
-end
-
 ---Checks if a project is part of a solution/solution filter or not
 ---@param target string Path to the solution or solution filter
 ---@param project string Full path to the project's csproj file


### PR DESCRIPTION
This code has been deprecated for some time now, and needs to be removed I want to do this before refactoring a bit with some (unfortunately) breaking changes for nvim 0.11 and vim.lsp.config

However, I will wait some time before merging something like that and bump minimum required version to 0.11