### PR TITLE
fix!: deprecate exe and args options and default cmd location

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ require("roslyn").setup({
     ---@type RoslynNvimConfig
     opts = {
         -- your configuration comes here; leave empty for default settings
+        -- NOTE: You must configure `cmd` in `config.cmd` unless you have installed via mason
     }
 }
 ```
@@ -91,17 +92,12 @@ The plugin comes with the following defaults:
 
 ```lua
 {
+    ---@type vim.lsp.ClientConfig
     config = {
-        cmd = {
-            "dotnet",
-            vim.fs.joinpath(vim.fn.stdpath("data"), "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll"),
-            "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path())
-        },
         -- Here you can pass in any options that that you would like to pass to `vim.lsp.start`.
         -- Use `:h vim.lsp.ClientConfig` to see all possible options.
         -- The only options that are overwritten and won't have any effect by setting here:
         --     - `name`
-        --     - `cmd`
         --     - `root_dir`
     },
     -- "auto" | "roslyn" | "off"

--- a/README.md
+++ b/README.md
@@ -47,11 +47,22 @@ There's currently an open [pull request](https://github.com/mason-org/mason-regi
   
   1. Navigate to [this feed](https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl), search for `Microsoft.CodeAnalysis.LanguageServer` and download the version matching your OS and architecture.
      > For nix users, install [roslyn-ls](https://search.nixos.org/packages?channel=unstable&show=roslyn-ls) and then you can config this plugin right away.
-  2. Unzip the downloaded `.nupkg` and copy the contents of `<zip root>/content/LanguageServer/<yourArch>` inside:
-     - **Linux**: `~/.local/share/nvim/roslyn`
-     - **Windows**: `%LOCALAPPDATA%\nvim-data\roslyn`
-       > **_TIP:_** You can also specify a custom path to the roslyn folder in the setup function.
-  3. Check if it's working by running `dotnet Microsoft.CodeAnalysis.LanguageServer.dll --version` in the `roslyn` directory.
+  2. Unzip the downloaded `.nupkg` and copy the contents of `<zip root>/content/LanguageServer/<yourArch>` to `<target>`
+  3. Check if it's working by running `dotnet Microsoft.CodeAnalysis.LanguageServer.dll --version` in the `<target>` directory.
+  4. Configure it like this:
+```lua
+require("roslyn").setup({
+    config = {
+        cmd = {
+            "dotnet",
+            "<target>/Microsoft.CodeAnalysis.LanguageServer.dll",
+            "--logLevel=Information",
+            "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()),
+            "--stdio",
+        },
+    },
+})
+```
 
 </details>
 
@@ -81,6 +92,11 @@ The plugin comes with the following defaults:
 ```lua
 {
     config = {
+        cmd = {
+            "dotnet",
+            vim.fs.joinpath(vim.fn.stdpath("data"), "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll"),
+            "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path())
+        },
         -- Here you can pass in any options that that you would like to pass to `vim.lsp.start`.
         -- Use `:h vim.lsp.ClientConfig` to see all possible options.
         -- The only options that are overwritten and won't have any effect by setting here:
@@ -88,22 +104,6 @@ The plugin comes with the following defaults:
         --     - `cmd`
         --     - `root_dir`
     },
-
-    --[[
-    -- if you installed `roslyn-ls` by nix, use the following:
-      exe = 'Microsoft.CodeAnalysis.LanguageServer',
-    ]]
-    exe = {
-        "dotnet",
-        vim.fs.joinpath(vim.fn.stdpath("data"), "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll"),
-    },
-    args = {
-        "--logLevel=Information", "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path())
-    },
-  --[[
-  -- args can be used to pass additional flags to the language server
-    ]]
-
     -- "auto" | "roslyn" | "off"
     --
     -- - "auto": Does nothing for filewatching, leaving everything as default

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -2,8 +2,6 @@ local M = {}
 
 ---@class InternalRoslynNvimConfig
 ---@field filewatching "auto" | "off" | "roslyn"
----@field exe string[]
----@field args string[]
 ---@field config vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field ignore_sln? fun(solution: string): boolean
@@ -14,8 +12,6 @@ local M = {}
 
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean | "auto" | "off" | "roslyn"
----@field exe? string|string[]
----@field args? string[]
 ---@field config? vim.lsp.ClientConfig
 ---@field choose_sln? fun(solutions: string[]): string?
 ---@field ignore_sln? fun(solution: string): boolean
@@ -37,18 +33,23 @@ local function default_capabilities()
         or default
 end
 
----@return string[]
-local function default_exe()
+---@return string[]?
+local function default_cmd()
     local data = vim.fn.stdpath("data") --[[@as string]]
 
     local mason_path = vim.fs.joinpath(data, "mason", "bin", "roslyn")
     local mason_installation = iswin and string.format("%s.cmd", mason_path) or mason_path
 
-    if vim.uv.fs_stat(mason_installation) ~= nil then
-        return { mason_installation }
-    else
-        return { "dotnet", vim.fs.joinpath(data, "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll") }
+    if vim.uv.fs_stat(mason_installation) == nil then
+        return nil
     end
+
+    return {
+        mason_installation,
+        "--logLevel=Information",
+        "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()),
+        "--stdio",
+    }
 end
 
 local function try_setup_mason()
@@ -79,14 +80,9 @@ end
 ---@type InternalRoslynNvimConfig
 local roslyn_config = {
     filewatching = "auto",
-    exe = default_exe(),
-    args = {
-        "--logLevel=Information",
-        "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()),
-        "--stdio",
-    },
-    ---@diagnostic disable-next-line: missing-fields
     config = {
+        ---@diagnostic disable-next-line: assign-type-mismatch
+        cmd = default_cmd(),
         capabilities = default_capabilities(),
     },
     choose_sln = nil,
@@ -101,13 +97,47 @@ function M.get()
     return roslyn_config
 end
 
+local function handle_deprecated_options()
+    ---@diagnostic disable-next-line: undefined-field
+    local exe = roslyn_config.exe
+    ---@diagnostic disable-next-line: undefined-field
+    local args = roslyn_config.args
+
+    if exe or args then
+        if args then
+            vim.notify(
+                "The `args` option is deprecated. Use `config.cmd` instead",
+                vim.log.levels.WARN,
+                { title = "roslyn.nvim" }
+            )
+        else
+            args = {
+                "--logLevel=Information",
+                "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()),
+                "--stdio",
+            }
+        end
+
+        vim.notify(
+            "The `exe` option is deprecated. Use `config.cmd` instead",
+            vim.log.levels.WARN,
+            { title = "roslyn.nvim" }
+        )
+
+        exe = type(exe) == "string" and { exe } or exe
+        ---@diagnostic disable-next-line: inject-field
+        roslyn_config.cmd = vim.list_extend(vim.deepcopy(exe), vim.deepcopy(args))
+    end
+end
+
 ---@param user_config? RoslynNvimConfig
 ---@return InternalRoslynNvimConfig
 function M.setup(user_config)
     try_setup_mason()
 
+    handle_deprecated_options()
+
     roslyn_config = vim.tbl_deep_extend("force", roslyn_config, user_config or {})
-    roslyn_config.exe = type(roslyn_config.exe) == "string" and { roslyn_config.exe } or roslyn_config.exe
 
     -- HACK: Enable filewatching to later just not watch any files
     -- This is to not make the server watch files and make everything super slow in certain situations

--- a/lua/roslyn/lsp.lua
+++ b/lua/roslyn/lsp.lua
@@ -1,32 +1,6 @@
 local roslyn_emitter = require("roslyn.roslyn_emitter")
 local M = {}
 
-local has_resolved_legacy_path = false
-
----@param roslyn_config InternalRoslynNvimConfig
-local function try_resolve_legacy_path(roslyn_config)
-    local legacy_path = vim.fs.joinpath(vim.fn.stdpath("data"), "roslyn", "Microsoft.CodeAnalysis.LanguageServer.dll")
-
-    if vim.uv.fs_stat(legacy_path) and not roslyn_config.config.cmd then
-        vim.notify(
-            "The default cmd location of roslyn is deprecated.\nEither download through mason, or specify the location through `config` option as specified in the README",
-            vim.log.levels.WARN,
-            { title = "roslyn.nvim" }
-        )
-        return vim.list_extend(
-            { "dotnet", legacy_path },
-            ---@diagnostic disable-next-line: undefined-field
-            vim.deepcopy(roslyn_config.args or {
-                "--logLevel=Information",
-                "--extensionLogDirectory=" .. vim.fs.dirname(vim.lsp.get_log_path()),
-                "--stdio",
-            })
-        )
-    end
-
-    return nil
-end
-
 ---@param bufnr integer
 ---@param root_dir string
 ---@param on_init fun(client: vim.lsp.Client)
@@ -34,12 +8,6 @@ function M.start(bufnr, root_dir, on_init)
     local roslyn_config = require("roslyn.config").get()
 
     local config = vim.deepcopy(roslyn_config.config)
-
-    if not config.cmd and not has_resolved_legacy_path then
-        ---@diagnostic disable-next-line: assign-type-mismatch
-        config.cmd = try_resolve_legacy_path(roslyn_config)
-        has_resolved_legacy_path = true
-    end
 
     config.name = "roslyn"
     config.root_dir = root_dir


### PR DESCRIPTION
While working on #178 I think I have finally gotten `vim.lsp.enable` to work. However, with that, I can't seem to find a good way to resolve this legacy config and warn the users about deprecated options.

Because of this, I think I want to soft deprecate these now. Warn the users if they are using them, but still resolve them.

Also warn about the default install location of roslyn. User now needs to provide this themselves