### PR TITLE
Remove restriction to c# files belonging to a project or solution

### DIFF
--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -40,9 +40,7 @@ return {
         local config = require("roslyn.config")
         local solutions = config.get().broad_search and utils.find_solutions_broad(bufnr) or utils.find_solutions(bufnr)
         local root_dir = utils.root_dir(bufnr, solutions)
-        if root_dir then
-            on_dir(root_dir)
-        end
+        on_dir(root_dir or vim.fn.getcwd())
     end,
     on_init = {
         function(client)


### PR DESCRIPTION
Roslyn has had support for the [C# Script](https://devblogs.microsoft.com/visualstudio/introducing-the-microsoft-roslyn-ctp/#c#-script-file-(.csx)-editing-support) fileformat ever since close to it's inception, and as far as I'm aware it remains the only tool capable of running and linting it (other tools are based on roslyn).

In addition to that, Microsoft has recently announced [their upcoming "dotnet run app.cs" feature](https://devblogs.microsoft.com/dotnet/announcing-dotnet-run-app/), which conceptually has a similar purpose, although implemented differently.

Both of these standards have in common, that they a) are (will be) supported by roslyn, and b) do not depend on being included in a C# Project or Visual Studio Solution (or anything similar) to work. That is why it doesn't make much sense to keep the artificial restriction in this repository. Furthermore, I think it is reasonable to assume the current working directory to be the project root, should a conventional marker not be found. 