### PR TITLE
Fix buffer highlighting after initialization

### DIFF
--- a/lua/roslyn/lsp/handlers.lua
+++ b/lua/roslyn/lsp/handlers.lua
@@ -19,8 +19,8 @@ return {
         local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
         local buffers = vim.lsp.get_buffers_by_client_id(ctx.client_id)
         for _, buf in ipairs(buffers) do
-            local params = { textDocument = vim.lsp.util.make_text_document_params(buf) }
-            client:request("textDocument/diagnostic", params, nil, buf)
+            vim.lsp.buf_detach_client(buf, ctx.client_id)
+            vim.lsp.buf_attach_client(buf, ctx.client_id)
         end
     end,
     ["workspace/_roslyn_projectHasUnresolvedDependencies"] = function()


### PR DESCRIPTION
I noticed that existing buffers do not automatically receive proper highlighting if they were around before the language server is started. `:e` fixes the highlighting but I thought it's better if it happens out of the box.

Neovim already does all the right requests (didOpen, semanticTokens etc.) when a buffer is attached to the client or the client is initialized. The roslyn language server however, reponds to the initialization request way before the server is actually ready and the solution is loaded. The simplest option seems to be to reattach the buffers when the server is ready.