### PR TITLE
Fix: prevent duplicate Roslyn servers for source-generated files

### DIFF
--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -23,6 +23,18 @@ return {
         },
     },
     root_dir = function(bufnr, on_dir)
+        local buf_name = vim.api.nvim_buf_get_name(bufnr)
+        
+        -- For source-generated files, use the root_dir from the existing client
+        if buf_name:match("^roslyn%-source%-generated://") then
+            local existing_client = vim.lsp.get_clients({ name = "roslyn" })[1]
+            if existing_client and existing_client.config.root_dir then
+                require("roslyn.log").log(string.format("lsp root_dir for source-generated file: %s", existing_client.config.root_dir))
+                on_dir(existing_client.config.root_dir)
+                return
+            end
+        end
+        
         local utils = require("roslyn.sln.utils")
         local config = require("roslyn.config")
         local solutions = config.get().broad_search and utils.find_solutions_broad(bufnr) or utils.find_solutions(bufnr)


### PR DESCRIPTION
This change ensures that when opening source-generated files (e.g., via Go to Definition), the existing Roslyn LSP client is reused if available, instead of launching a new server instance.

This avoids the issue where a second server attaches to the buffer and clears its contents.

Fixes the issue described here: https://github.com/seblyng/roslyn.nvim/issues/226

