### PR TITLE
feat: Allow configuring the roslyn-language-server as daemon_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ server.
 ## ⚡️ Requirements
 
 - Neovim >= 0.12.0
-- Roslyn language server downloaded locally
+- Roslyn language server >= `5.12.0-1.26453.19` downloaded locally
 - .NET SDK installed and `dotnet` command available
 
 ## Difference to nvim-lspconfig
@@ -155,24 +155,29 @@ opts = {
     -- This will always attach to the target in `vim.g.roslyn_nvim_selected_solution`.
     -- NOTE: You can use `:Roslyn target` to change the target
     lock_target = false,
-
-    -- Share a single language server between multiple clients (like multiple neovim
-    -- instances, or other editors on the same machine) instead of starting a
-    -- dedicated server per instance.
-    -- The first instance launches the server and wamrs it up.
-    -- The lsp then relays over named pipes.
-    -- Solutions are still opened per client, but runtime and metadata caches are
-    -- shared, reducing memory usage and startup time for subsequent clients.
-    daemon = {
-        enabled = false,
-
-        -- Seconds the daemon stays alive after the last client disconnects.
-        -- nil: Uses roslyn-language-server default (900s).
-        -- -1: keeps it alive forever. 
-        --  0: daemon exits immediately
-        keep_alive = nil,
-    },
 }
+```
+
+### Daemon mode
+
+The server is started in daemon mode.  
+A single language server is shared between multiple clients (like multiple neovim instances, 
+or other editors on the same machine) instead of starting a dedicated server per instance.  
+Clients use **named pipes** to relay but solutions are still opened per client.  
+The runtime overhead and metadata caches are shared, reducing memory usage and startup time.  
+
+The daemon **stays alive for 900 seconds** - default as of 5.12.0-1.26453.19 - **after the last client disconnects**.  
+This can be changed with the environment variable
+`ROSLYN_LANGUAGE_SERVER_DAEMON_KEEPALIVE` (`-1` keeps it alive forever, `0`
+exits immediately), or by appending `--daemonKeepAlive <seconds>` to the cmd.  
+(`vim.env.ROSLYN_LANGUAGE_SERVER_DAEMON_KEEPALIVE = "0"`)
+
+To opt out of daemon mode, override the cmd without `--daemon-mode`:
+
+```lua
+vim.lsp.config("roslyn", {
+    cmd = { require("roslyn.utils").get_roslyn_lsp_path(), "--stdio" },
+})
 ```
 
 To configure language server specific settings sent to the server, you can use the `vim.lsp.config` interface with `roslyn` as the name of the server.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ To opt out of daemon mode, override the cmd without `--daemon-mode`:
 
 ```lua
 vim.lsp.config("roslyn", {
-    cmd = { require("roslyn.utils").get_roslyn_lsp_path(), "--stdio" },
+    cmd = { "/path/to/roslyn-language-server-or-microsoft-codeanalysis-languageserver", "--stdio" },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,23 @@ opts = {
     -- This will always attach to the target in `vim.g.roslyn_nvim_selected_solution`.
     -- NOTE: You can use `:Roslyn target` to change the target
     lock_target = false,
+
+    -- Share a single language server between multiple clients (like multiple neovim
+    -- instances, or other editors on the same machine) instead of starting a
+    -- dedicated server per instance.
+    -- The first instance launches the server and wamrs it up.
+    -- The lsp then relays over named pipes.
+    -- Solutions are still opened per client, but runtime and metadata caches are
+    -- shared, reducing memory usage and startup time for subsequent clients.
+    daemon = {
+        enabled = false,
+
+        -- Seconds the daemon stays alive after the last client disconnects.
+        -- nil: Uses roslyn-language-server default (900s).
+        -- -1: keeps it alive forever. 
+        --  0: daemon exits immediately
+        keep_alive = nil,
+    },
 }
 ```
 

--- a/lsp/roslyn.lua
+++ b/lsp/roslyn.lua
@@ -2,7 +2,13 @@
 return {
     name = "roslyn",
     filetypes = { "cs", "razor" },
-    cmd = { require("roslyn.utils").get_roslyn_lsp_path(), "--stdio" },
+    cmd = {
+        require("roslyn.utils").get_roslyn_lsp_path(),
+        "--stdio",
+        "--daemon-mode",
+        "--clientProcessId",
+        tostring(vim.uv.os_getpid()),
+    },
     cmd_env = {
         Configuration = vim.env.Configuration or "Debug",
         -- Fixes LSP navigation in decompiled files for systems with symlinked TMPDIR (macOS)

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -8,10 +8,6 @@ local M = {}
 ---@field path string?
 ---@field args? string[]
 
----@class RoslynNvimDaemonConfig
----@field enabled boolean
----@field keep_alive? integer
-
 ---@class InternalRoslynNvimConfig
 ---@field filewatching "auto" | "off" | "roslyn"
 ---@field choose_target? fun(targets: string[]): string?
@@ -19,7 +15,6 @@ local M = {}
 ---@field broad_search boolean
 ---@field lock_target boolean
 ---@field debug boolean
----@field daemon RoslynNvimDaemonConfig
 
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean | "auto" | "off" | "roslyn"
@@ -28,7 +23,6 @@ local M = {}
 ---@field broad_search? boolean
 ---@field lock_target? boolean
 ---@field debug? boolean
----@field daemon? RoslynNvimDaemonConfig
 
 ---@type InternalRoslynNvimConfig
 local roslyn_config = {
@@ -38,30 +32,7 @@ local roslyn_config = {
     broad_search = false,
     lock_target = false,
     debug = false,
-    daemon = {
-        enabled = false,
-    },
 }
-
-local function configure_daemon(daemon)
-    local thin_client = require("roslyn.utils").get_roslyn_thin_client_path()
-    if not thin_client then
-        vim.notify(
-            "roslyn.nvim: `daemon.enabled` is set, but the `roslyn-language-server` thin client was not found. "
-            .. "If on mason please update to >= 5.12.0-1.26453.19",
-            vim.log.levels.WARN,
-            { title = "roslyn.nvim" }
-        )
-        return
-    end
-
-    local cmd = { thin_client, "--stdio", "--daemon-mode", "--clientProcessId", tostring(vim.uv.os_getpid()) }
-    if daemon.keep_alive then
-        vim.list_extend(cmd, { "--daemonKeepAlive", tostring(daemon.keep_alive) })
-    end
-
-    vim.lsp.config("roslyn", { cmd = cmd })
-end
 
 function M.get()
     return roslyn_config
@@ -86,10 +57,6 @@ function M.setup(user_config)
                 },
             },
         })
-    end
-
-    if roslyn_config.daemon.enabled then
-        configure_daemon(roslyn_config.daemon)
     end
 
     return roslyn_config

--- a/lua/roslyn/config.lua
+++ b/lua/roslyn/config.lua
@@ -8,6 +8,10 @@ local M = {}
 ---@field path string?
 ---@field args? string[]
 
+---@class RoslynNvimDaemonConfig
+---@field enabled boolean
+---@field keep_alive? integer
+
 ---@class InternalRoslynNvimConfig
 ---@field filewatching "auto" | "off" | "roslyn"
 ---@field choose_target? fun(targets: string[]): string?
@@ -15,6 +19,7 @@ local M = {}
 ---@field broad_search boolean
 ---@field lock_target boolean
 ---@field debug boolean
+---@field daemon RoslynNvimDaemonConfig
 
 ---@class RoslynNvimConfig
 ---@field filewatching? boolean | "auto" | "off" | "roslyn"
@@ -23,6 +28,7 @@ local M = {}
 ---@field broad_search? boolean
 ---@field lock_target? boolean
 ---@field debug? boolean
+---@field daemon? RoslynNvimDaemonConfig
 
 ---@type InternalRoslynNvimConfig
 local roslyn_config = {
@@ -32,7 +38,30 @@ local roslyn_config = {
     broad_search = false,
     lock_target = false,
     debug = false,
+    daemon = {
+        enabled = false,
+    },
 }
+
+local function configure_daemon(daemon)
+    local thin_client = require("roslyn.utils").get_roslyn_thin_client_path()
+    if not thin_client then
+        vim.notify(
+            "roslyn.nvim: `daemon.enabled` is set, but the `roslyn-language-server` thin client was not found. "
+            .. "If on mason please update to >= 5.12.0-1.26453.19",
+            vim.log.levels.WARN,
+            { title = "roslyn.nvim" }
+        )
+        return
+    end
+
+    local cmd = { thin_client, "--stdio", "--daemon-mode", "--clientProcessId", tostring(vim.uv.os_getpid()) }
+    if daemon.keep_alive then
+        vim.list_extend(cmd, { "--daemonKeepAlive", tostring(daemon.keep_alive) })
+    end
+
+    vim.lsp.config("roslyn", { cmd = cmd })
+end
 
 function M.get()
     return roslyn_config
@@ -57,6 +86,10 @@ function M.setup(user_config)
                 },
             },
         })
+    end
+
+    if roslyn_config.daemon.enabled then
+        configure_daemon(roslyn_config.daemon)
     end
 
     return roslyn_config

--- a/lua/roslyn/utils.lua
+++ b/lua/roslyn/utils.lua
@@ -27,36 +27,6 @@ function M.get_roslyn_lsp_path()
     return "Microsoft.CodeAnalysis.LanguageServer"
 end
 
---- Temporary code. TODO - Remove in a few weeks after everyone installed at least 5.12.0-1.26453.19 because at that point we changed the mason link
---- Resolves the `roslyn-language-server` thin client that ships next to the server binary.
----@return string?
-function M.get_roslyn_thin_client_path()
-    local sysname = vim.uv.os_uname().sysname:lower()
-    local iswin = not not (sysname:find("windows") or sysname:find("mingw"))
-    local thin_client_bin = iswin and "roslyn-language-server.exe" or "roslyn-language-server"
-    local server_bin = iswin and "Microsoft.CodeAnalysis.LanguageServer.exe" or "Microsoft.CodeAnalysis.LanguageServer"
-
-    local server_path = vim.fn.exepath(M.get_roslyn_lsp_path())
-    if server_path == "" then
-        return nil
-    end
-    server_path = vim.uv.fs_realpath(server_path) or server_path
-
-    local basename = vim.fs.basename(server_path)
-    if basename == thin_client_bin then
-        return server_path
-    end
-
-    if basename == server_bin then
-        local sibling = vim.fs.joinpath(vim.fs.dirname(server_path), thin_client_bin)
-        if vim.fn.executable(sibling) == 1 then
-            return sibling
-        end
-    end
-
-    return nil
-end
-
 function M.populate_virtual_buffer_content(lsp_client, uri, bufnr)
     assert(lsp_client, "Must have a `roslyn` client to load roslyn source generated file")
 

--- a/lua/roslyn/utils.lua
+++ b/lua/roslyn/utils.lua
@@ -6,7 +6,7 @@ local function get_mason_path()
     return expanded_mason == "$MASON" and vim.fs.joinpath(vim.fn.stdpath("data"), "mason") or expanded_mason
 end
 
----@return string?
+---@return string
 function M.get_roslyn_lsp_path()
     local sysname = vim.uv.os_uname().sysname:lower()
     local iswin = not not (sysname:find("windows") or sysname:find("mingw"))
@@ -25,6 +25,36 @@ function M.get_roslyn_lsp_path()
     end
 
     return "Microsoft.CodeAnalysis.LanguageServer"
+end
+
+--- Temporary code. TODO - Remove in a few weeks after everyone installed at least 5.12.0-1.26453.19 because at that point we changed the mason link
+--- Resolves the `roslyn-language-server` thin client that ships next to the server binary.
+---@return string?
+function M.get_roslyn_thin_client_path()
+    local sysname = vim.uv.os_uname().sysname:lower()
+    local iswin = not not (sysname:find("windows") or sysname:find("mingw"))
+    local thin_client_bin = iswin and "roslyn-language-server.exe" or "roslyn-language-server"
+    local server_bin = iswin and "Microsoft.CodeAnalysis.LanguageServer.exe" or "Microsoft.CodeAnalysis.LanguageServer"
+
+    local server_path = vim.fn.exepath(M.get_roslyn_lsp_path())
+    if server_path == "" then
+        return nil
+    end
+    server_path = vim.uv.fs_realpath(server_path) or server_path
+
+    local basename = vim.fs.basename(server_path)
+    if basename == thin_client_bin then
+        return server_path
+    end
+
+    if basename == server_bin then
+        local sibling = vim.fs.joinpath(vim.fs.dirname(server_path), thin_client_bin)
+        if vim.fn.executable(sibling) == 1 then
+            return sibling
+        end
+    end
+
+    return nil
 end
 
 function M.populate_virtual_buffer_content(lsp_client, uri, bufnr)


### PR DESCRIPTION
Allows running `roslyn-language-server` in daemon mode.  
This vastly improves startup when the cache is warm.  
Additionally about 13% memory could be saved during my tests on the huge monoliths.

The [mason package](https://github.com/Crashdummyy/mason-registry/commit/107b97b2b7c686001dd35212db3e0c2a150999ed) now points to the file that is correctly named `roslyn-language-server` and used like that already [in the dotnet tool](https://www.nuget.org/packages/roslyn-language-server) .
